### PR TITLE
fix gnosis dnp

### DIFF
--- a/package_variants/gnosis/dappnode_package.json
+++ b/package_variants/gnosis/dappnode_package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nethermind-xdai.public.dappnode.eth",
+  "name": "nethermind-xdai.dnp.dappnode.eth",
   "version": "0.1.0",
   "exposable": [
     {


### PR DESCRIPTION
nethermind gnosis is dnp, not public: https://github.com/dappnode/DAppNodePackage-nethermind-xdai/blob/67792f6a1ddde180f4ede4ee9d361776cebb6ac8/dappnode_package.json#L2C1-L3C1