### PR TITLE
bump NethermindEth/nethermind to 1.36.1, dappnode/staker-package-scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -4,7 +4,7 @@
   "upstream": [
     {
       "repo": "NethermindEth/nethermind",
-      "version": "1.36.0",
+      "version": "1.36.1",
       "arg": "UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: nethermind
       args:
-        UPSTREAM_VERSION: 1.36.0
+        UPSTREAM_VERSION: 1.36.1
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /data
     restart: unless-stopped

--- a/package_variants/gnosis/dappnode_package.json
+++ b/package_variants/gnosis/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "nethermind-xdai.dnp.dappnode.eth",
-  "version": "1.0.72",
+  "version": "1.0.73",
   "requirements": {
     "minimumDappnodeVersion": "0.3.12",
     "notInstalledPackages": ["nimbus-gnosis.dnp.dappnode.eth"]

--- a/package_variants/hoodi/dappnode_package.json
+++ b/package_variants/hoodi/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoodi-nethermind.dnp.dappnode.eth",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "exposable": [
     {
       "name": "hoodi Nethermind JSON RPC",

--- a/package_variants/mainnet/dappnode_package.json
+++ b/package_variants/mainnet/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "nethermind.public.dappnode.eth",
-  "version": "1.0.77",
+  "version": "1.0.78",
   "exposable": [
     {
       "name": "Nethermind JSON RPC",


### PR DESCRIPTION
Bumps upstream version

- [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind) from 1.36.0 to [1.36.1](https://github.com/NethermindEth/nethermind/releases/tag/1.36.1)
- [dappnode/staker-package-scripts](https://github.com/dappnode/staker-package-scripts) from v0.1.2 to [v0.1.2](https://github.com/dappnode/staker-package-scripts/releases/tag/v0.1.2)