### PR TITLE
bump NethermindEth/nethermind to 1.37.1, dappnode/staker-package-scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -4,7 +4,7 @@
   "upstream": [
     {
       "repo": "NethermindEth/nethermind",
-      "version": "1.37.0",
+      "version": "1.37.1",
       "arg": "UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: nethermind
       args:
-        UPSTREAM_VERSION: 1.37.0
+        UPSTREAM_VERSION: 1.37.1
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /data
     restart: unless-stopped


### PR DESCRIPTION
Bumps upstream version

- [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind) from 1.37.0 to [1.37.1](https://github.com/NethermindEth/nethermind/releases/tag/1.37.1)
- [dappnode/staker-package-scripts](https://github.com/dappnode/staker-package-scripts) from v0.1.2 to [v0.1.2](https://github.com/dappnode/staker-package-scripts/releases/tag/v0.1.2)